### PR TITLE
remove build-image process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 build-image:
-	docker build --no-cache -t proofreading .
+	docker build --no-cache -t chie8842/tensorflow_docs_proofreading .
 
 run-check:
 	docker run \
   -it \
   --rm \
   -v $(PWD)/..:/usr/local/documents \
-  proofreading \
+  chie8842/tensorflow_docs_proofreading \
   /bin/ash proofreading/proofreading.sh
 
 clear-output:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ $ git clone https://github.com/tensorflow/docs
 $ cd docs/
 $ git clone https://github.com/tfug/proofreading proofreading
 $ cd proofreading
-$ make build-image   # create Docker image to run text lint
 $ make run-check       # run text lint on the Docker container
 $ make clear-output   # remove temporary files
 ```


### PR DESCRIPTION
dockerイメージをbuildするの面倒だし頻繁に変更する予定がないので、DockerHubからpullするようにしました。
DockerHubリポジトリは一旦私個人のものをつかっていますが、githubと同じくtfugのアカウントを作るならそっちに移します！