### PR TITLE
change docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 build-image:
-	docker build --no-cache -t chie8842/tensorflow_docs_proofreading .
+	docker build --no-cache -t tfug/proofreading .
 
 run-check:
 	docker run \
   -it \
   --rm \
   -v $(PWD)/..:/usr/local/documents \
-  chie8842/tensorflow_docs_proofreading \
+  tfug/proofreading \
   /bin/ash proofreading/proofreading.sh
 
 clear-output:


### PR DESCRIPTION
#4 に関して諸々考慮してこうしてみましたが、どうでしょ？

- Docker Hub の [tfug/proofreading](https://cloud.docker.com/repository/docker/tfug/proofreading) と、このリポジトリを紐付け
  - master にマージされたら、このリポジトリの `Dockerfile` をもとに自動でビルドが走る
  - `make run-check` は [tfug/proofreading](https://cloud.docker.com/repository/docker/tfug/proofreading) を使ってチェック