### PR TITLE
Fix terminologies txt to use TAB instead of double white spaces.

### DIFF
--- a/terminologies.txt
+++ b/terminologies.txt
@@ -82,4 +82,4 @@ Eager実行	Eager Execution
 eager 実行	Eager Execution
 Eager 実行	Eager Execution
 購買	勾配
-常套句  イディオム
+常套句	イディオム


### PR DESCRIPTION
TSV 形式でなければいけないところ、半角スペースが入ってしまっていたので修正しました 🙇 