### PR TITLE
Fix getting docker context

### DIFF
--- a/bin/build-docker
+++ b/bin/build-docker
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-docker build --no-cache -t tfug/proofreading .
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+docker build --no-cache -t tfug/proofreading ${SCRIPT_DIR}/../


### PR DESCRIPTION
`docker-build` で proofreading ディレクトリ直下に Dockerfile の存在を仮定していたので、シェルスクリプトファイルからの相対パスで指定するようにしました